### PR TITLE
Re-add support for vte291 >0.52

### DIFF
--- a/src/Gtk/TermBox.vala
+++ b/src/Gtk/TermBox.vala
@@ -255,7 +255,7 @@ public class TermBox : Gtk.Box {
 
 		#else 
  
-		term.feed_child(cmd, -1);  
+		term.feed_child(cmd.to_utf8());  
 		
 		#endif
 	}


### PR DESCRIPTION
Previously added with https://github.com/teejee2008/polo/commit/b97070471fc5e4d65a52f3b2562d6e5598f9530d to fix #206, nullified by https://github.com/teejee2008/polo/commit/20d02ea862855d3c1249f000f31be55f99293faf

Patch added to the 2 AUR pkgbuilds which build from source